### PR TITLE
css custom properties for box shadows

### DIFF
--- a/packages/react/src/breadcrumbs.tsx
+++ b/packages/react/src/breadcrumbs.tsx
@@ -165,7 +165,7 @@ export function Breadcrumbs({ className }: BreadcrumbsProps) {
             overflowY: "auto",
             backgroundColor: "var(--vj-bg-panel, #252526)",
             border: "1px solid var(--vj-border, #333333)",
-            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            boxShadow: "var(--vj-shadow-subtle, 0 4px 12px rgba(0,0,0,0.3))",
           }}
         >
           {suggestions.map((s, i) => (

--- a/packages/react/src/context-menu.tsx
+++ b/packages/react/src/context-menu.tsx
@@ -63,7 +63,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
         backgroundColor: "var(--vj-bg-panel, #252526)",
         border: "1px solid var(--vj-border, #454545)",
         borderRadius: 4,
-        boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
+        boxShadow: "var(--vj-shadow, 0 4px 12px rgba(0,0,0,0.5))",
         padding: "4px 0",
         minWidth: 160,
       }}

--- a/packages/react/src/enum-input.tsx
+++ b/packages/react/src/enum-input.tsx
@@ -153,7 +153,7 @@ export function EnumInput({
             overflowY: "auto",
             backgroundColor: "var(--vj-bg-panel, #252526)",
             border: "1px solid var(--vj-border, #333333)",
-            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            boxShadow: "var(--vj-shadow-subtle, 0 4px 12px rgba(0,0,0,0.3))",
           }}
         >
           {suggestions.map((s, i) => (

--- a/packages/react/src/json-editor.tsx
+++ b/packages/react/src/json-editor.tsx
@@ -50,6 +50,8 @@ const DEFAULT_CSS_VARS: Record<string, string> = {
   "--vj-input-bg": "#3c3c3c",
   "--vj-input-border": "#555555",
   "--vj-error": "#f48771",
+  "--vj-shadow": "0 4px 12px rgba(0,0,0,0.5)",
+  "--vj-shadow-subtle": "0 4px 12px rgba(0,0,0,0.3)",
   "--vj-font": "monospace",
   "--vj-input-font-size": "13px",
 };


### PR DESCRIPTION
Closes #15

- Add `--vj-shadow` and `--vj-shadow-subtle` CSS custom properties for theming box shadows
- Replace hardcoded `boxShadow` values in breadcrumbs, enum-input, and context-menu with variables
- Add defaults to `DEFAULT_CSS_VARS` in json-editor.tsx