### PR TITLE
fix: VS Code extension activation and YAML file support

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -24,6 +24,7 @@ const extensionConfig = {
   target: "node18",
   sourcemap: !isProduction,
   minify: isProduction,
+  mainFields: ["module", "main"],
   alias: workspaceAliases,
 };
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -15,7 +15,8 @@
   ],
   "activationEvents": [
     "onCustomEditor:visualJson.editor",
-    "onView:visualJson.panel"
+    "onView:visualJson.panel",
+    "onCommand:visualJson.openWithVisualJson"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -46,7 +47,7 @@
           "type": "webview",
           "id": "visualJson.panel",
           "name": "visual-json",
-          "when": "resourceLangId == json || resourceLangId == jsonc || resourceLangId == yaml"
+          "when": "resourceLangId == json || resourceLangId == jsonc || resourceLangId == yaml || resourceLangId == dockercompose || resourceLangId == github-actions-workflow || resourceLangId == home-assistant"
         }
       ]
     },

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -28,11 +28,17 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("visualJson.openWithVisualJson", () => {
       const activeEditor = vscode.window.activeTextEditor;
+      const yamlLike = new Set([
+        "yaml",
+        "dockercompose",
+        "github-actions-workflow",
+        "home-assistant",
+      ]);
       if (
         activeEditor &&
         (activeEditor.document.languageId === "json" ||
           activeEditor.document.languageId === "jsonc" ||
-          activeEditor.document.languageId === "yaml")
+          yamlLike.has(activeEditor.document.languageId))
       ) {
         vscode.commands.executeCommand(
           "vscode.openWith",


### PR DESCRIPTION
## Summary

- Fix extension failing to activate with `Cannot find module './impl/format'` by adding `mainFields: ["module", "main"]` to esbuild config so `jsonc-parser` ESM build is bundled instead of UMD
- Add `onCommand:visualJson.openWithVisualJson` activation event so the command works before the custom editor or panel is opened
- Support `docker-compose.yml` and other YAML-derived language IDs (`dockercompose`, `github-actions-workflow`, `home-assistant`)